### PR TITLE
Updated to openjdk8 and added openssl packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.3
 
 ENV DDB_VERSION latest
 
-RUN apk update && apk add openjdk7 \
+RUN apk update && apk add openssl openjdk8 \
 	&& wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_${DDB_VERSION}.tar.gz -O /tmp/dynamo.tar.gz \
 	&& mkdir -p /opt/dynamodb \
 	&& tar -xzvf /tmp/dynamo.tar.gz -C /opt/dynamodb \


### PR DESCRIPTION
Hello. I started using this image today but it no longer builds locally. The current image you have on dockerhub still works, but it won't build anymore because the latest version of _dynamodb local_ isn't compatible (it seems) with openjdk7. Also there was an SSL issue trying to download the tar file that is simple enough to fix by adding the `openssl` package.

__Changes__:

* Updated to `openjdk8` (for compatibility with the latest dynamodb local)
* Added `openssl` (to fix ['ssl_helper' error with wget](https://github.com/google/cadvisor/issues/1131#issuecomment-257382321))